### PR TITLE
[Docs]: Correct README.md to match initialize declaration with string argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ target_link_libraries(your_target PRIVATE logcoe)
 #include <logcoe.hpp>
 
 int main() {
-    // Initialize with INFO level, console enabled, file disabled
+    // Initialize with INFO level, no default source (empty string), console enabled, file disabled
+    // logs will be printed as [timestamp] [log_level]: <log_message>
     logcoe::initialize(logcoe::LogLevel::INFO, std::string{}, true, false);
     
     logcoe::info("Application started");
@@ -64,8 +65,9 @@ int main() {
 #include <fstream>
 
 int main() {
-    // Enable both console and file output with DEBUG level
-    logcoe::initialize(logcoe::LogLevel::DEBUG, std::string{},true, true, "app.log");
+    // Enable both console and file output with DEBUG level and default source as logcoe
+    // logs will be printed as [timestamp] [log_level] [logcoe]: <log_message>
+    logcoe::initialize(logcoe::LogLevel::DEBUG, "logcoe", true, true, "app.log");
     
     // Customize time format
     logcoe::setTimeFormat("%H:%M:%S");

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ logcoe::initialize();
 // Full configuration
 logcoe::initialize(
     logcoe::LogLevel::DEBUG,  // Log level
+    "logcoe",                 //default source
     true,                     // Enable console
     true,                     // Enable file
     "application.log"         // Filename

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ target_link_libraries(your_target PRIVATE logcoe)
 
 int main() {
     // Initialize with INFO level, console enabled, file disabled
-    logcoe::initialize(logcoe::LogLevel::INFO, true, false);
+    logcoe::initialize(logcoe::LogLevel::INFO, std::string{}, true, false);
     
     logcoe::info("Application started");
     logcoe::warning("This is a warning message");
@@ -65,7 +65,7 @@ int main() {
 
 int main() {
     // Enable both console and file output with DEBUG level
-    logcoe::initialize(logcoe::LogLevel::DEBUG, true, true, "app.log");
+    logcoe::initialize(logcoe::LogLevel::DEBUG, std::string{},true, true, "app.log");
     
     // Customize time format
     logcoe::setTimeFormat("%H:%M:%S");

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ logcoe::initialize();
 // Full configuration
 logcoe::initialize(
     logcoe::LogLevel::DEBUG,  // Log level
-    "logcoe",                 //default source
+    "logcoe",                 // Default source
     true,                     // Enable console
     true,                     // Enable file
     "application.log"         // Filename
@@ -176,7 +176,7 @@ void worker_thread(int id) {
 }
 
 int main() {
-    logcoe::initialize(logcoe::LogLevel::INFO,  std::string{}, false, true, "concurrent.log");
+    logcoe::initialize(logcoe::LogLevel::INFO, std::string{}, false, true, "concurrent.log");
     
     std::vector<std::thread> workers;
     for (int i = 0; i < 10; ++i) {

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ void worker_thread(int id) {
 }
 
 int main() {
-    logcoe::initialize(logcoe::LogLevel::INFO, false, true, "concurrent.log");
+    logcoe::initialize(logcoe::LogLevel::INFO,  std::string{}, false, true, "concurrent.log");
     
     std::vector<std::thread> workers;
     for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
Modified the initialize function declaration to accept a string parameter in README.md as per the signature of that function in section 2 of Quick start. 