### PR TITLE
[Refactor]: Use init counter instead of boolean initialized

### DIFF
--- a/tests/logcoe_test.cpp
+++ b/tests/logcoe_test.cpp
@@ -15,12 +15,13 @@ protected:
     void SetUp() override
     {
         testFilename = "test_logfile_" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count()) + ".log";
-        logcoe::shutdown();
+
+        while(logcoe::isInitialized()) { logcoe::shutdown(); }
     }
 
     void TearDown() override
     {
-        logcoe::shutdown();
+        while(logcoe::isInitialized()) { logcoe::shutdown(); }
 
         if (std::filesystem::exists(testFilename))
             std::filesystem::remove(testFilename);

--- a/tests/logcoe_thread_test.cpp
+++ b/tests/logcoe_thread_test.cpp
@@ -21,12 +21,12 @@ protected:
     {
         testFilename = "thread_test_" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count()) + ".log";
 
-        logcoe::shutdown();
+        while(logcoe::isInitialized()) { logcoe::shutdown(); }
     }
 
     void TearDown() override
     {
-        logcoe::shutdown();
+        while(logcoe::isInitialized()) { logcoe::shutdown(); }
 
         if (std::filesystem::exists(testFilename))
             std::filesystem::remove(testFilename);


### PR DESCRIPTION
- Support multiple logcoe::initialize() calls with no errors
- shutdown() only runs when --s_initCounter == 0
- Allow users to use logcoe in their application while dependencies use logcoe
